### PR TITLE
feat: add CDN proxy endpoint

### DIFF
--- a/src/lib/components/PostCard.svelte
+++ b/src/lib/components/PostCard.svelte
@@ -8,12 +8,12 @@
   <figure class="post-card-graphic">
     {#if post.videoUrl}
       <video width="100%" autoplay loop muted playsinline>
-        <source src={post.videoUrl} type="video/mp4" />
+        <source src={`/api/cdn-sanity?url=${post.videoUrl}`} type="video/mp4" />
         <track src="" kind="captions" srclang="en" label="English" />
         Your browser does not support the video tag.
       </video>
     {:else if post.imageUrl}
-      <img src={post.imageUrl} alt={post.title} width="100%" />
+      <img src={`/api/cdn-sanity?url=${post.imageUrl}`} alt={post.title} width="100%" />
     {:else}
       <img src={`${website}/og-image.jpg`} alt={post.title} width="100%" />
     {/if}

--- a/src/routes/api/cdn-sanity/+server.ts
+++ b/src/routes/api/cdn-sanity/+server.ts
@@ -1,0 +1,31 @@
+import { error } from '@sveltejs/kit'
+import type { RequestHandler } from './$types'
+
+export const GET: RequestHandler = async ({ url }) => {
+  const targetUrl = url.searchParams.get('url')
+
+  if (!targetUrl || !targetUrl.startsWith('https://cdn.sanity.io/')) {
+    throw error(400, 'Invalid or missing Sanity CDN URL')
+  }
+
+  try {
+    const res = await fetch(targetUrl)
+
+    if (!res.ok) {
+      throw error(502, 'Failed to fetch image from Sanity')
+    }
+
+    const contentType = res.headers.get('content-type') ?? 'image/jpeg'
+    const buffer = await res.arrayBuffer()
+
+    return new Response(buffer, {
+      headers: {
+        'Content-Type': contentType,
+        'Cache-Control': 'public, max-age=31536000'
+      }
+    })
+  } catch (err) {
+    console.error('Proxy error:', err)
+    throw error(500, 'Internal Server Error')
+  }
+}

--- a/src/routes/post/[slug]/+page.svelte
+++ b/src/routes/post/[slug]/+page.svelte
@@ -16,7 +16,7 @@
     pageState = new PostPageState(),
     parsedEl: HTMLElement
 
-  const cover = data.post.imageUrl ? data.post.imageUrl : `${website}/og-image.jpg`,
+  const cover = data.post.imageUrl ? `/api/cdn-sanity?url=${data.post.imageUrl}` : `${website}/og-image.jpg`,
     headings = data.post.headings ? data.post.headings.map((item) => item.replace(/-/g, ' ')) : [],
     keywords = [data.post.title, ...headings, ...data.post.tags],
     f = `https://www.facebook.com/sharer/sharer.php?u=${website}/post/${data.post.slug}`,
@@ -99,12 +99,12 @@
   <figure class="post-card-graphic max-w-4xl mx-auto my-10 overflow-clip lg:rounded-lg">
     {#if data.post.videoUrl}
       <video autoplay loop muted playsinline width="100%">
-        <source src={data.post.videoUrl} type="video/mp4" />
+        <source src={`/api/cdn-sanity?url=${data.post.videoUrl}`} type="video/mp4" />
         <track src="" kind="captions" srclang="en" label="English" />
         Your browser does not support the video tag.
       </video>
     {:else if data.post.imageUrl}
-      <img src={data.post.imageUrl} alt={data.post.title} width="100%" />
+      <img src={`/api/cdn-sanity?url=${data.post.imageUrl}`} alt={data.post.title} width="100%" />
     {:else}
       <img src={`${website}/og-image.jpg`} alt={data.post.title} width="100%" />
     {/if}


### PR DESCRIPTION
Added /api/cdn-sanity endpoint to fetch and serve images and videos from cdn.sanity.io
via our own domain. This improves Lighthouse best practices score by eliminating
third-party cookie warnings from Sanity's CDN.